### PR TITLE
Modal can now be closed on mobile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ notifications:
   email: false
 
 sudo: false
+
+before_install:
+  - "npm install -g npm"

--- a/example/entry.jsx
+++ b/example/entry.jsx
@@ -5,4 +5,21 @@ import data from './data.js'
 // expose React for debugging
 window.React = React
 
-Modal.open(<div><Modal {...data}><button>This button should not close the modal</button></Modal></div>)
+const appEl = document.getElementById('app')
+const modal = (
+  <Modal {...data}>
+    <button>This button should not close the modal</button>
+    <button onClick={Modal.close}>Close modal</button>
+  </Modal>
+)
+const openModal = () => Modal.open(modal)
+// override the server render
+React.render(
+  <div>
+    <button onClick={openModal}>Open modal</button>
+    {new Array(1e4).join('content ')}
+  </div>
+, appEl)
+
+// open the modal to start
+openModal()

--- a/index.jsx
+++ b/index.jsx
@@ -1,8 +1,13 @@
 import React, {Component} from 'react'
 import {addons} from 'react/addons'
+import injectTapEventPlugin from 'react-tap-event-plugin'
+injectTapEventPlugin()
 const {shouldComponentUpdate} = addons.PureRenderMixin
 const namespace = 'modal'
 const container = `${namespace}-container`
+
+// turn on touch events
+React.initializeTouchEvents(true)
 
 export default class Modal extends Component {
   // use the pure-render mixin without the mixin. This allows us to use es6
@@ -50,6 +55,7 @@ export default class Modal extends Component {
     return (
       <div className={container}
         onClick={this.onContainerClick.bind(this)}
+        onTouchTap={this.onContainerClick.bind(this)}
       >
         <div className={namespace} role="alertdialog" aria-describedby="removed">
           {/* eslint-disable react/prop-types */}

--- a/index.jsx
+++ b/index.jsx
@@ -21,21 +21,36 @@ export default class Modal extends Component {
       React.render(modalInstance, document.getElementById(container))
     }
   }
-  static close (e) {
-    if (process.browser){
-      const isModalContainer = e
-        ? e.target.classList.contains(container)
-        : true
 
-      if (isModalContainer){
-        React.unmountComponentAtNode(document.getElementById(container))
+  static close () {
+    if (process.browser){
+      const containerEl = document.getElementById(container)
+
+      if (containerEl) {
+        // NOTE: there is a React bug that can cause this to throw
+        // https://github.com/facebook/react/issues/2605
+        // sucks, but it's safe to ignore. Things still work.
+        React.unmountComponentAtNode(containerEl)
+        containerEl.parentElement.removeChild(containerEl)
       }
     }
   }
 
+  isContainer (e) {
+    if (process.browser){
+      return e.target.classList.contains(container)
+    }
+  }
+
+  onContainerClick (e) {
+    if (this.isContainer(e)) Modal.close()
+  }
+
   render () {
     return (
-      <div className={container} onClick={ Modal.close }>
+      <div className={container}
+        onClick={this.onContainerClick.bind(this)}
+      >
         <div className={namespace} role="alertdialog" aria-describedby="removed">
           {/* eslint-disable react/prop-types */}
           {this.props.children}

--- a/index.jsx
+++ b/index.jsx
@@ -51,10 +51,18 @@ export default class Modal extends Component {
     if (this.isContainer(e)) Modal.close()
   }
 
+  // the wheel event comes before the scroll event, cancel it instead of the
+  // scroll because scroll isn't cancelable. http://codepen.io/somethingkindawierd/blog/react-mixin-scroll-lock
+  onWheel (e) {
+    if (this.isContainer(e)) e.preventDefault()
+  }
+
   render () {
     return (
       <div className={container}
         onClick={this.onContainerClick.bind(this)}
+        onWheel={this.onWheel.bind(this)}
+        onTouchMove={this.onWheel.bind(this)}
         onTouchTap={this.onContainerClick.bind(this)}
       >
         <div className={namespace} role="alertdialog" aria-describedby="removed">

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react": "^0.13.2"
   },
   "dependencies": {
-    "@getable/variables": "^1.0.1"
+    "@getable/variables": "^1.0.1",
+    "react-tap-event-plugin": "^0.1.6"
   }
 }


### PR DESCRIPTION
- modal now listens to the tap event so it can be closed on mobile
- modal can now be closed programatically
- better example
- prevent body scrolling when modal is open
